### PR TITLE
fix: default import in readme docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Now we need to configure the dependency injection container before use. Dependen
 until the application really needs them. Your DI container initialization function - `configureDI` will include:
 
 ```typescript
-import DIContainer from "rsdi";
+import { DIContainer } from "rsdi";
 
 export type AppDIContainer = ReturnType<typeof configureDI>;
 
@@ -205,9 +205,9 @@ export const configureDI = async () => {
     .extend(addValidators);
 }
 
-// buildDatabaseDependencies.ts
+// addDataAccessDependencies.ts
 export type DIWithPool = Awaited<ReturnType<typeof buildDatabaseDependencies>>;
-export const buildDatabaseDependencies = async () => {
+export const addDataAccessDependencies = async () => {
   const pool = await createDatabasePool();
   const longRunningPool = await createLongRunningDatabasePool();
   return new DIContainer()
@@ -216,9 +216,9 @@ export const buildDatabaseDependencies = async () => {
 };
 
 //  addValidators.ts
-    export type DIWithValidators = ReturnType<typeof addValidators>;
-    export const addValidators = (container: DIWithPool) => {
-      return container
-        .add('myValidatorA', ({ a, b, c }) => new MyValidatorA(a, b, c))
-        .add('myValidatorB', ({ a, b, c }) => new MyValidatorB(a, b, c));
-    };
+export type DIWithValidators = ReturnType<typeof addValidators>;
+export const addValidators = (container: DIWithPool) => {
+  return container
+    .add('myValidatorA', ({ a, b, c }) => new MyValidatorA(a, b, c))
+    .add('myValidatorB', ({ a, b, c }) => new MyValidatorB(a, b, c));
+};

--- a/docs/async_factory_resolver.md
+++ b/docs/async_factory_resolver.md
@@ -19,7 +19,7 @@ class UserRepository {
 
 // configureDI.ts
 import { createConnections } from "my-orm-library";
-import DIContainer from "rsdi";
+import { DIContainer } from "rsdi";
 
 async function configureDI() {
   // initialize async factories before DI container initialisation

--- a/docs/strict_types.md
+++ b/docs/strict_types.md
@@ -3,7 +3,7 @@
 
 ```typescript
 
-import DIContainer from "../DIContainer";
+import { DIContainer } from "../DIContainer";
 import { Bar, Foo } from "./fakeClasses";
 
 const container = new DIContainer()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rsdi",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "description": "TypeScript dependency injection container. Strong types without decorators.",
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION
Fixes incorrect documentation 

```typescript 
import DIContainer from "rsdi";
# => 
import { DIContainer } from "rsdi";
```

Documentation has been migrated from previous version.