### PR TITLE
Custom instance for dependency at method `get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,3 +222,30 @@ export const addValidators = (container: DIWithPool) => {
     .add('myValidatorA', ({ a, b, c }) => new MyValidatorA(a, b, c))
     .add('myValidatorB', ({ a, b, c }) => new MyValidatorB(a, b, c));
 };
+```
+
+If you need a custom dependency to use specific context you can do as follows as example:
+
+```typescript
+class Logger {
+  public context: string | null = null;
+}
+
+class Controller {
+  constructor(public logger: Logger) {}
+}
+
+container
+  .add("logger", () => new Logger())
+  .add("controller", ({ logger }) => new Controller(logger));
+
+const logger = new Logger();
+logger.context = "UserController";
+const controller = container.get("controller", { logger });
+
+console.log(controller.logger.context); // UserController
+
+const dashboardController = container.get("controller");
+
+console.log(dashboardController.logger.context); // null
+```

--- a/src/DIContainer.ts
+++ b/src/DIContainer.ts
@@ -106,6 +106,7 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
    */
   public get<Name extends keyof ContainerResolvers>(
     dependencyName: Name,
+    changeContext?: { [key: string]: any },
   ): ContainerResolvers[Name] {
     if (this.resolvedDependencies[dependencyName] !== undefined) {
       return this.resolvedDependencies[dependencyName];
@@ -114,6 +115,10 @@ export class DIContainer<ContainerResolvers extends ResolvedDependencies = {}> {
     const resolver = this.resolvers[dependencyName];
     if (!resolver) {
       throw new DependencyIsMissingError(dependencyName as string);
+    }
+
+    if (changeContext) {
+      return resolver({ ...this.context, ...changeContext });
     }
 
     this.resolvedDependencies[dependencyName] = resolver(this.context);

--- a/src/types.ts
+++ b/src/types.ts
@@ -46,5 +46,6 @@ export type IDIContainer<ContainerResolvers extends ResolvedDependencies = {}> =
     ) => ReturnType<E>;
     get: <Name extends keyof ContainerResolvers>(
       dependencyName: Name,
+      changeContext?: { [key: string]: any },
     ) => ContainerResolvers[Name];
   };


### PR DESCRIPTION
There is a case when the application need to set a custom context to a certain dependency, for example:
I have a logger class that controls all logs of the application and in some cases there is the need to put some more context to the logger in a specific instance as the url, and others data.

Thinking about that situation i changed the signature of `get` method adding the parameter `changeContext` as opitional, for when it is passed i merge the current context with the parameter and it resolves the class.

Some cons that i faced while implementing:

- i don't get how to resolve dependencies of dependencies with the same context for that specific instance, for example:

```typescript
    class Logger {
      public context: string | null = null;
    }

    class Service {
      constructor(public logger: Logger) {}
    }

    class Controller {
      constructor(
        public logger: Logger,
        public service: Service,
      ) {}
    }

    const container = new DIContainer()
      .add("logger", () => new Logger())
      .add("service", ({ logger }) => new Service(logger))
      .add(
        "controller",
        ({ logger, service }) => new Controller(logger, service),
      );

    const logger = new Logger();
    logger.context = "custom context";
    const controller = container.get("controller", { logger });

    expect(controller.logger.context).toBe("custom context");
    expect(controller.service.logger.context).toBe("custom context"); // here it says that logger is undefined
```

to solve that scenario i have to pass all the dependencies that requires logger for controller as `customContext`, I've write a test for this scenario too. If you have some idea of how to solve i'm open to discuss ideias.